### PR TITLE
Add support for title for table.

### DIFF
--- a/table/xtable.css
+++ b/table/xtable.css
@@ -632,3 +632,9 @@ tr.highlighted > td.button-drag i{
 tr.selected > td{
   background: #b3e5fc !important;
 }
+
+.table-title {
+  text-align: center;
+  margin: 0;
+  padding-top: 15px;
+}

--- a/table/xtable.js
+++ b/table/xtable.js
@@ -17,6 +17,10 @@ Inputs:
 div_id: the id of the div in which to place the table, e.g. test_table for 
     <div class="exaptive-table-component table-responsive-vertical shadow-z-1" id="test_table"></div>
 
+title: a string that represents the title to use for the table, 
+    this is put into an `h1` tag at the top of the table and has the CSS 
+    class of `table-title`
+
 data: a dictionary containing two elements:
     columns: an array of dictionaries representing column definition, including id and label (used for display).
     rows: an array of dictionaries, one per row of data (assumes every column is defined in the dictionary, even if the data is empty). Each row is a dictionary, with the keys being column IDs and the values being either numeric, text, boolean or empty/null
@@ -43,8 +47,9 @@ Options: a dictionary containing the following elements:
 
 */
 
-var XTable = function(divId, data, options) {
+var XTable = function(divId, title, data, options) {
   this.divId = '';
+  this.title = '';
   this.rows = [];
   this.columns = [];
   this.options = {};
@@ -55,6 +60,7 @@ var XTable = function(divId, data, options) {
   this.sortAscending = true;
 
   this.divId = divId;
+  this.title = title;
   this.options = options;
   this.rowOrder = options.rowOrder ? options.rowOrder.split(' ') : [];
   this.updateData(data);
@@ -202,6 +208,7 @@ XTable.prototype.render = function() {
   let divId = this.divId;
   let columns = this.getColumns();
   let rows = this.getRows();
+  let titleHTML = '<h1 class="table-title">' + this.title + '</h1>';
 
         let headerHTML = '<thead><tr>';
         if (this.options.selection.indicator) { headerHTML += '<th></th>'; }
@@ -222,7 +229,7 @@ XTable.prototype.render = function() {
 
         headerHTML += '</tr></thead>';
   
-        let tableHTML = `<table class='table'>${headerHTML}<tbody>`;
+        let tableHTML = `${titleHTML}<table class='table'>${headerHTML}<tbody>`;
         rows.forEach(entity => {
             tableHTML += `<tr data-id='${entity.id}'>`;
 

--- a/table/xtable_example.html
+++ b/table/xtable_example.html
@@ -106,7 +106,7 @@ The components in this repository are distributed under the terms of the GNU Gen
             "rowOrder": ""
         }
         
-        var table = new XTable("xtable1", data, options1);
+        var table = new XTable("xtable1", 'Example 01', data, options1);
 
         
         <!-- Example of more sophisticated table with single selection and row striping -->
@@ -127,7 +127,7 @@ The components in this repository are distributed under the terms of the GNU Gen
             "rowOrder": ""
         }
         
-        var table = new XTable("xtable2", data, options2);
+        var table = new XTable("xtable2", 'Example 02', data, options2);
 
         
         <!-- Example of more sophisticated table with multiple selection and dragging/dropping of rows -->
@@ -148,7 +148,7 @@ The components in this repository are distributed under the terms of the GNU Gen
             "rowOrder": "age desc"
         }
         
-        var table = new XTable("xtable3", data, options3);
+        var table = new XTable("xtable3", 'Example 03', data, options3);
     </script>
 
 


### PR DESCRIPTION
Add title parameter to Xtable function so that tables can have titles. The title is simply a string that gets wrapped in `h1` tags and added above the table element. Update documentation to show how to use title parameter. Update example HTMLto use the title parameter. Update CSS with styling for title element.